### PR TITLE
Recovery

### DIFF
--- a/macosvm/VMInstance.h
+++ b/macosvm/VMInstance.h
@@ -20,7 +20,7 @@
 @public
     int cpus;
     unsigned long ram;
-    BOOL audio, use_serial, pty, use_pl011;
+    BOOL audio, use_serial, pty, use_pl011, recovery, dfu;
 }
 
 @property (strong) VZMacOSRestoreImage *restoreImage;
@@ -39,6 +39,17 @@
 
 @end
 
+@interface _VZVirtualMachineStartOptions : NSObject
+
+@property BOOL restartAction;
+@property BOOL panicAction;
+@property BOOL stopInIBootStage1;
+@property BOOL stopInIBootStage2;
+@property BOOL bootMacOSRecovery;
+@property BOOL forceDFU;
+
+@end
+
 @interface VMInstance : NSObject
 {
     @public
@@ -48,6 +59,7 @@
 
 @property (strong) VZVirtualMachine *virtualMachine;
 @property (strong) VMSpec *spec;
+@property (strong) _VZVirtualMachineStartOptions *options;
 
 - (instancetype) initWithSpec: (VMSpec*) spec;
 - (void) start;
@@ -58,4 +70,8 @@
 
 @interface _VZPL011SerialPortConfiguration : VZSerialPortConfiguration
 - (instancetype _Nonnull)init;
+@end
+
+@interface VZVirtualMachine()
+- (void)_startWithOptions:(_VZVirtualMachineStartOptions *_Nonnull)options completionHandler:(void (^_Nonnull)(NSError * _Nullable errorOrNil))completionHandler;
 @end

--- a/macosvm/VMInstance.h
+++ b/macosvm/VMInstance.h
@@ -20,7 +20,7 @@
 @public
     int cpus;
     unsigned long ram;
-    BOOL audio, use_serial, pty;
+    BOOL audio, use_serial, pty, use_pl011;
 }
 
 @property (strong) VZMacOSRestoreImage *restoreImage;
@@ -54,4 +54,8 @@
 - (BOOL) stop;
 - (void) performVM: (id) target selector: (SEL) aSelector withObject:(nullable id)anArgument;
 
+@end
+
+@interface _VZPL011SerialPortConfiguration : VZSerialPortConfiguration
+- (instancetype _Nonnull)init;
 @end

--- a/macosvm/VMInstance.m
+++ b/macosvm/VMInstance.m
@@ -16,6 +16,8 @@
     os = nil;
     bootInfo = nil;
     audio = NO;
+    recovery = NO;
+    dfu = NO;
     _restoreImage = nil;
     use_serial = YES;
     use_pl011 = NO;
@@ -524,6 +526,9 @@ void add_unlink_on_exit(const char *fn); /* from main.m - a bit hacky but more s
     //queue = dispatch_get_main_queue(); //dispatch_queue_create("macvm", DISPATCH_QUEUE_SERIAL);
     queue = dispatch_queue_create("macvm", DISPATCH_QUEUE_SERIAL);
     self.virtualMachine = [[VZVirtualMachine alloc] initWithConfiguration:_spec queue:queue];
+    self.options = [[_VZVirtualMachineStartOptions alloc] init];
+    self.options.bootMacOSRecovery = self.spec->recovery;
+    self.options.forceDFU = self.spec->dfu;
     NSLog(@" init OK");
     return self;
 }
@@ -545,7 +550,7 @@ void add_unlink_on_exit(const char *fn); /* from main.m - a bit hacky but more s
 }
 
 - (void) start_ {
-    [_virtualMachine startWithCompletionHandler:^(NSError *err) {
+    [_virtualMachine _startWithOptions:self.options completionHandler:^(NSError *err) {
         NSLog(@"start completed err=%@", err ? err : @"nil");
         if (err)
             @throw [NSException exceptionWithName:@"VMStartError" reason:[err description] userInfo:nil];

--- a/macosvm/main.m
+++ b/macosvm/main.m
@@ -458,7 +458,7 @@ int main(int ac, char**av) {
  Usage: %s [-g|--[no-]gui] [--[no-]audio] [--restore <path>] [--ephemeral]\n\
            [--disk <path>[,ro][,size=<spec>][,keep]] [--aux <path>]\n\
            [--net <spec>] [-c <cpu>] [-m <ram>] [--no-serial] [--pty]\n\
-           [--[no-]pl011] <config.json>\n\
+           [--[no-]pl011] [--recovery] [--dfu] <config.json>\n\
         %s --version\n\
         %s -h\n\
 \n\
@@ -466,7 +466,7 @@ int main(int ac, char**av) {
  If no CPU/RAM is specified then image's minimal settings are used.\n\
 \n\
  If no --restore is performed then settings are read from the configuration file\n\
- and only --gui / --audio / --pl011 options are honored.\n\
+ and only --gui / --audio / --pl011 / --recovery / --dfu  options are honored.\n\
  Size specifications allow suffix k, m and g for the powers of 1024.\n\
 \n\
  Examples:\n\
@@ -519,6 +519,8 @@ int main(int ac, char**av) {
                 if (!strcmp(av[i], "--audio")) { spec->audio = YES; continue; }
                 if (!strcmp(av[i], "--pl011")) { spec->use_pl011 = YES; continue; }
                 if (!strcmp(av[i], "--no-pl011")) { spec->use_pl011 = NO; continue; }
+                if (!strcmp(av[i], "--recovery")) { spec->recovery = YES; continue; }
+                if (!strcmp(av[i], "--dfu")) { spec->dfu = YES; continue; }
             }
         } else {
             if (configPath) {

--- a/macosvm/main.m
+++ b/macosvm/main.m
@@ -457,7 +457,8 @@ int main(int ac, char**av) {
                 case 'h': printf("\n\
  Usage: %s [-g|--[no-]gui] [--[no-]audio] [--restore <path>] [--ephemeral]\n\
            [--disk <path>[,ro][,size=<spec>][,keep]] [--aux <path>]\n\
-           [--net <spec>] [-c <cpu>] [-m <ram>] [--no-serial] [--pty] <config.json>\n\
+           [--net <spec>] [-c <cpu>] [-m <ram>] [--no-serial] [--pty]\n\
+           [--[no-]pl011] <config.json>\n\
         %s --version\n\
         %s -h\n\
 \n\
@@ -465,7 +466,7 @@ int main(int ac, char**av) {
  If no CPU/RAM is specified then image's minimal settings are used.\n\
 \n\
  If no --restore is performed then settings are read from the configuration file\n\
- and only --gui / --audio options are honored.\n\
+ and only --gui / --audio / --pl011 options are honored.\n\
  Size specifications allow suffix k, m and g for the powers of 1024.\n\
 \n\
  Examples:\n\
@@ -516,6 +517,8 @@ int main(int ac, char**av) {
                 if (!strcmp(av[i], "--no-gui")) { main.useGUI = NO; continue; }
                 if (!strcmp(av[i], "--no-audio")) { spec->audio = NO; continue; }
                 if (!strcmp(av[i], "--audio")) { spec->audio = YES; continue; }
+                if (!strcmp(av[i], "--pl011")) { spec->use_pl011 = YES; continue; }
+                if (!strcmp(av[i], "--no-pl011")) { spec->use_pl011 = NO; continue; }
             }
         } else {
             if (configPath) {


### PR DESCRIPTION
Virtualization.Framework has a few private APIs that can come handy when debugging issues: A PL011 emulator so you can get iBoot & kernel debug output and forcing parameters to get the VM to boot in RecoveryOS or DFU mode.

This PR adds support for all 3 of them: The PL011 configuration can be stored permanently as part of the vm config. Recovery and DFU are only command line switches, because they will only be useful during manual recovery.